### PR TITLE
rendering: refactor console out of overlay

### DIFF
--- a/src/rendering/console.rs
+++ b/src/rendering/console.rs
@@ -1,4 +1,4 @@
-use egui::CtxRef;
+use egui::{CtxRef, Ui};
 
 pub(crate) struct Console {
     text_input: String,
@@ -11,29 +11,31 @@ impl Console {
         }
     }
 
-    pub fn render(&mut self, ctx: &CtxRef) {
+    pub fn show(&mut self, ctx: &CtxRef) {
         egui::TopBottomPanel::bottom("bottom_panel")
             .resizable(true)
             .min_height(200.0)
-            .show(ctx, |ui| {
-                ui.heading("Console");
-                ui.separator();
+            .show(ctx, |ui| self.ui(ui));
+    }
 
-                let text_style = egui::TextStyle::Body;
-                let row_height = ui.fonts()[text_style].row_height();
-                let num_rows = 6;
-                egui::ScrollArea::vertical()
-                    .auto_shrink([false; 2])
-                    .show_rows(ui, row_height, num_rows, |ui, row_range| {
-                        for row in row_range {
-                            ui.label(format!("This is row {}/{}", row + 1, num_rows));
-                        }
-                    });
-                ui.end_row();
-                ui.add(
-                    egui::TextEdit::singleline(&mut self.text_input)
-                        .hint_text("Enter a command like 'exit' or `pause`"),
-                );
+    fn ui(&mut self, ui: &mut Ui) {
+        ui.heading("Console");
+        ui.separator();
+
+        let text_style = egui::TextStyle::Body;
+        let row_height = ui.fonts()[text_style].row_height();
+        let num_rows = 6;
+        egui::ScrollArea::vertical()
+            .auto_shrink([false; 2])
+            .show_rows(ui, row_height, num_rows, |ui, row_range| {
+                for row in row_range {
+                    ui.label(format!("This is row {}/{}", row + 1, num_rows));
+                }
             });
+        ui.end_row();
+        ui.add(
+            egui::TextEdit::singleline(&mut self.text_input)
+                .hint_text("Enter a command like 'exit' or `pause`"),
+        );
     }
 }

--- a/src/rendering/console.rs
+++ b/src/rendering/console.rs
@@ -1,0 +1,39 @@
+use egui::CtxRef;
+
+pub(crate) struct Console {
+    text_input: String,
+}
+
+impl Console {
+    pub(crate) fn new() -> Self {
+        Self {
+            text_input: Default::default(),
+        }
+    }
+
+    pub fn render(&mut self, ctx: &CtxRef) {
+        egui::TopBottomPanel::bottom("bottom_panel")
+            .resizable(true)
+            .min_height(200.0)
+            .show(ctx, |ui| {
+                ui.heading("Console");
+                ui.separator();
+
+                let text_style = egui::TextStyle::Body;
+                let row_height = ui.fonts()[text_style].row_height();
+                let num_rows = 6;
+                egui::ScrollArea::vertical()
+                    .auto_shrink([false; 2])
+                    .show_rows(ui, row_height, num_rows, |ui, row_range| {
+                        for row in row_range {
+                            ui.label(format!("This is row {}/{}", row + 1, num_rows));
+                        }
+                    });
+                ui.end_row();
+                ui.add(
+                    egui::TextEdit::singleline(&mut self.text_input)
+                        .hint_text("Enter a command like 'exit' or `pause`"),
+                );
+            });
+    }
+}

--- a/src/rendering/mod.rs
+++ b/src/rendering/mod.rs
@@ -1,4 +1,5 @@
 pub mod overlay;
+mod console;
 
 use crate::{detouring::prelude::*, game::zrender::RENDER_MANAGER, HookLibrary};
 use anyhow::Result;

--- a/src/rendering/overlay.rs
+++ b/src/rendering/overlay.rs
@@ -1,5 +1,6 @@
 use std::sync::Mutex;
 
+use super::console::Console;
 use egui::CtxRef;
 use egui_directx::{Painter, PainterDX12, WindowInput};
 use lazy_static::lazy_static;
@@ -21,7 +22,7 @@ pub struct Overlay {
     capture: bool,
     painter: Option<PainterDX12>,
     render: bool,
-    text_input: String,
+    console: Console,
 }
 
 impl Overlay {
@@ -32,7 +33,7 @@ impl Overlay {
             capture: false,
             painter: None,
             render: true,
-            text_input: Default::default(),
+            console: Console::new(),
         }
     }
 
@@ -85,49 +86,10 @@ impl Overlay {
             let input = input.get_input();
 
             let (_, shapes) = ctx.run(input, |ctx| {
-                {
-                    let frame = egui::Frame::none();
-                    egui::TopBottomPanel::top("title_bar")
-                        .frame(frame)
-                        .show(ctx, |ui| {
-                            ui.vertical_centered(|ui| {
-                                ui.add_space(5.0);
-                                ui.label("hm3-sandbox");
-                                ui.small(format!(
-                                    "Press ~ to {} menu",
-                                    match self.capture {
-                                        true => "close",
-                                        false => "open",
-                                    }
-                                ));
-                            })
-                        });
-                }
+                Self::render_title_bar(ctx, self.capture);
 
                 if self.capture {
-                    egui::TopBottomPanel::bottom("bottom_panel")
-                        .resizable(true)
-                        .min_height(200.0)
-                        .show(ctx, |ui| {
-                            ui.heading("Console");
-                            ui.separator();
-
-                            let text_style = egui::TextStyle::Body;
-                            let row_height = ui.fonts()[text_style].row_height();
-                            let num_rows = 6;
-                            egui::ScrollArea::vertical()
-                                .auto_shrink([false; 2])
-                                .show_rows(ui, row_height, num_rows, |ui, row_range| {
-                                    for row in row_range {
-                                        ui.label(format!("This is row {}/{}", row + 1, num_rows));
-                                    }
-                                });
-                            ui.end_row();
-                            ui.add(
-                                egui::TextEdit::singleline(&mut self.text_input)
-                                    .hint_text("Enter a command like 'exit' or `pause`"),
-                            );
-                        });
+                    self.console.render(ctx);
                 }
             });
 
@@ -136,6 +98,25 @@ impl Overlay {
                 .paint_meshes(ctx.tessellate(shapes), ctx.pixels_per_point())
                 .unwrap();
         }
+    }
+
+    fn render_title_bar(ctx: &CtxRef, capture: bool) {
+        let frame = egui::Frame::none();
+        egui::TopBottomPanel::top("title_bar")
+            .frame(frame)
+            .show(ctx, |ui| {
+                ui.vertical_centered(|ui| {
+                    ui.add_space(5.0);
+                    ui.label("hm3-sandbox");
+                    ui.small(format!(
+                        "Press ~ to {} menu",
+                        match capture {
+                            true => "close",
+                            false => "open",
+                        }
+                    ));
+                })
+            });
     }
 }
 

--- a/src/rendering/overlay.rs
+++ b/src/rendering/overlay.rs
@@ -86,10 +86,10 @@ impl Overlay {
             let input = input.get_input();
 
             let (_, shapes) = ctx.run(input, |ctx| {
-                Self::render_title_bar(ctx, self.capture);
+                Self::show_title_bar(ctx, self.capture);
 
                 if self.capture {
-                    self.console.render(ctx);
+                    self.console.show(ctx);
                 }
             });
 
@@ -100,7 +100,7 @@ impl Overlay {
         }
     }
 
-    fn render_title_bar(ctx: &CtxRef, capture: bool) {
+    fn show_title_bar(ctx: &CtxRef, capture: bool) {
         let frame = egui::Frame::none();
         egui::TopBottomPanel::top("title_bar")
             .frame(frame)


### PR DESCRIPTION
Makes it easier to reason about what's console specific. No behavioural changes.

Used an associated function instead of a method for `render_title_bar` as using a method would require a second `self` borrow which upsets the ~~baby Jeebus~~ rustc.